### PR TITLE
Add Ripple token and NFT support

### DIFF
--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/ripple/TestRippleTransactionSigner.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/ripple/TestRippleTransactionSigner.kt
@@ -19,20 +19,25 @@ class TestRippleTransactionSigner {
 
     @Test
     fun testRippleTransactionSigning() {
+        val operation = Ripple.OperationPayment.newBuilder()
+        operation.apply {
+            amount = 10
+            destination = "rU893viamSnsfP3zjzM2KPxjqZjXSXK6VF"
+        }
         val signingInput = Ripple.SigningInput.newBuilder()
         signingInput.apply {
-            account = "rDpysuumkweqeC7XdNgYNtzL5GxbdsmrtF"
-            amount = 29_000_000
-            destination = "rU893viamSnsfP3zjzM2KPxjqZjXSXK6VF"
-            fee = 200_000
-            sequence = 1
-            privateKey = ByteString.copyFrom(PrivateKey("ba005cd605d8a02e3d5dfd04234cef3a3ee4f76bfbad2722d1fb5af8e12e6764".toHexByteArray()).data())
+            account = "rfxdLwsZnoespnTDDb1Xhvbc8EFNdztaoq"
+            fee = 10
+            sequence = 32268248
+            lastLedgerSequence = 32268269
+            privateKey = ByteString.copyFrom(PrivateKey("a5576c0f63da10e584568c8d134569ff44017b0a249eb70657127ae04f38cc77".toHexByteArray()).data())
+            opPayment = operation.build()
         }
 
         val sign = AnySigner.sign(signingInput.build(), XRP, SigningOutput.parser())
         val signBytes = sign.encoded.toByteArray()
 
-        assertEquals(signBytes.toHex(), "0x12000022800000002400000001614000000001ba8140684000000000030d407321026cc34b92cefb3a4537b3edb0b6044c04af27c01583c577823ecc69a9a21119b6744630440220067f20b3eebfc7107dd0bcc72337a236ac3be042c0469f2341d76694a17d4bb9022048393d7ee7dcb729783b33f5038939ddce1bb8337e66d752974626854556bbb681148400b6b6d08d5d495653d73eda6804c249a5148883148132e4e20aecf29090ac428a9c43f230a829220d")
+        assertEquals(signBytes.toHex(), "0x12000022000000002401ec5fd8201b01ec5fed61400000000000000a68400000000000000a732103d13e1152965a51a4a9fd9a8b4ea3dd82a4eba6b25fcad5f460a2342bb650333f74463044022037d32835c9394f39b2cfd4eaf5b0a80e0db397ace06630fa2b099ff73e425dbc02205288f780330b7a88a1980fa83c647b5908502ad7de9a44500c08f0750b0d9e8481144c55f5a78067206507580be7bb2686c8460adff983148132e4e20aecf29090ac428a9c43f230a829220d")
     }
 
 }

--- a/src/XRP/BinaryCoding.h
+++ b/src/XRP/BinaryCoding.h
@@ -9,6 +9,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <vector>
+#include "Data.h"
 
 namespace TW::Ripple {
 
@@ -17,20 +18,20 @@ enum class FieldType;
 /// Encodes a field type.
 inline void encodeType(FieldType type, int key, std::vector<uint8_t>& data) {
     const auto typeValue = static_cast<int>(type);
-    if (static_cast<int>(typeValue) <= 0xf) {
+    if (typeValue <= 0xf) {
         if (key <= 0xf) {
-            data.push_back(static_cast<uint8_t>((typeValue << 4) | key));
+            data.emplace_back(static_cast<uint8_t>((typeValue << 4) | key));
         } else {
-            data.push_back(static_cast<uint8_t>(typeValue << 4));
-            data.push_back(static_cast<uint8_t>(key));
+            data.emplace_back(static_cast<uint8_t>(typeValue << 4));
+            data.emplace_back(static_cast<uint8_t>(key));
         }
-    } else if(key <= 0xf) {
-        data.push_back(static_cast<uint8_t>(key));
-        data.push_back(static_cast<uint8_t>(typeValue));
+    } else if (key <= 0xf) {
+        data.emplace_back(static_cast<uint8_t>(key));
+        data.emplace_back(static_cast<uint8_t>(typeValue));
     } else {
-        data.push_back(0);
-        data.push_back(static_cast<uint8_t>(typeValue));
-        data.push_back(static_cast<uint8_t>(key));
+        data.emplace_back(0);
+        data.emplace_back(static_cast<uint8_t>(typeValue));
+        data.emplace_back(static_cast<uint8_t>(key));
     }
 }
 
@@ -56,10 +57,8 @@ inline void encodeBytes(std::vector<uint8_t> bytes, std::vector<uint8_t>& data) 
     data.insert(data.end(), bytes.begin(), bytes.end());
 }
 
-inline void encode0(int len, std::vector<uint8_t>& data) {
-    for (int i = 0; i < len; i++) {
-        data.push_back(0);
-    }
+inline void encodeZeros(std::size_t len, std::vector<uint8_t>& data) {
+    append(data, Data(len));
 }
 
 } // namespace TW::Ripple

--- a/src/XRP/BinaryCoding.h
+++ b/src/XRP/BinaryCoding.h
@@ -17,10 +17,19 @@ enum class FieldType;
 /// Encodes a field type.
 inline void encodeType(FieldType type, int key, std::vector<uint8_t>& data) {
     const auto typeValue = static_cast<int>(type);
-    if (key <= 0xf) {
-        data.push_back(static_cast<uint8_t>((typeValue << 4) | key));
+    if (static_cast<int>(typeValue) <= 0xf) {
+        if (key <= 0xf) {
+            data.push_back(static_cast<uint8_t>((typeValue << 4) | key));
+        } else {
+            data.push_back(static_cast<uint8_t>(typeValue << 4));
+            data.push_back(static_cast<uint8_t>(key));
+        }
+    } else if(key <= 0xf) {
+        data.push_back(static_cast<uint8_t>(key));
+        data.push_back(static_cast<uint8_t>(typeValue));
     } else {
-        data.push_back(static_cast<uint8_t>(typeValue << 4));
+        data.push_back(0);
+        data.push_back(static_cast<uint8_t>(typeValue));
         data.push_back(static_cast<uint8_t>(key));
     }
 }
@@ -45,6 +54,12 @@ inline void encodeVariableLength(size_t length, std::vector<uint8_t>& data) {
 inline void encodeBytes(std::vector<uint8_t> bytes, std::vector<uint8_t>& data) {
     encodeVariableLength(bytes.size(), data);
     data.insert(data.end(), bytes.begin(), bytes.end());
+}
+
+inline void encode0(int len, std::vector<uint8_t>& data) {
+    for (int i = 0; i < len; i++) {
+        data.push_back(0);
+    }
 }
 
 } // namespace TW::Ripple

--- a/src/XRP/Signer.cpp
+++ b/src/XRP/Signer.cpp
@@ -101,7 +101,6 @@ Proto::SigningOutput Signer::sign(const Proto::SigningInput& input) noexcept {
 
 void Signer::sign(const PrivateKey& privateKey, Transaction& transaction) const noexcept {
     /// See https://github.com/trezor/trezor-core/blob/master/src/apps/ripple/sign_tx.py#L59
-    //transaction.flags |= fullyCanonical; // deprecated
     transaction.pub_key = privateKey.getPublicKey(TWPublicKeyTypeSECP256k1).bytes;
 
     auto unsignedTx = transaction.getPreImage();

--- a/src/XRP/Signer.cpp
+++ b/src/XRP/Signer.cpp
@@ -10,39 +10,99 @@
 
 namespace TW::Ripple {
 
-static const int64_t fullyCanonical = 0x80000000;
+//static const int64_t fullyCanonical = 0x80000000; // deprecated
 
 Proto::SigningOutput Signer::sign(const Proto::SigningInput& input) noexcept {
     auto output = Proto::SigningOutput();
 
-    const int64_t tag = input.destination_tag();
-    if (tag > std::numeric_limits<uint32_t>::max() || tag < 0) {
-        output.set_error(Common::Proto::SigningError::Error_invalid_memo);
-        return output;
+    auto transaction =
+        Transaction(
+            /* fee */input.fee(),
+            /* flags */input.flags(),
+            /* sequence */input.sequence(),
+            /* last_ledger_sequence */input.last_ledger_sequence(),
+            /* account */Address(input.account()));
+    switch (input.operation_oneof_case()) {
+        case Proto::SigningInput::kOpPayment: {
+            const int64_t tag = input.op_payment().destination_tag();
+            if (tag > std::numeric_limits<uint32_t>::max() || tag < 0) {
+                output.set_error(Common::Proto::SigningError::Error_invalid_memo);
+                return output;
+            }
+
+            switch (input.op_payment().amount_oneof_case()) {
+                case Proto::OperationPayment::kAmount:
+                    transaction.createXrpPayment(
+                        /* amount */input.op_payment().amount(),
+                        /* destination */input.op_payment().destination(),
+                        /* destination_tag*/tag);
+                    break;
+
+                case Proto::OperationPayment::kCurrencyAmt:
+                    transaction.createTokenPayment(
+                        /* currency */input.op_payment().currency_amt().currency(),
+                        /* value */input.op_payment().currency_amt().value(),
+                        /* issuer */input.op_payment().currency_amt().issuer(),
+                        /* destination */input.op_payment().destination(),
+                        /* destination_tag*/tag);
+                    break;
+
+                default:
+                    break;
+            }
+
+            break;
+        }
+
+        case Proto::SigningInput::kOpNftokenBurn:
+            transaction.createNFTokenBurn(
+                /* nftoken_id */input.op_nftoken_burn().nftoken_id());
+            break;
+
+        case Proto::SigningInput::kOpNftokenCreateOffer:
+            transaction.createNFTokenCreateOffer(
+                /* token_id */input.op_nftoken_create_offer().nftoken_id(),
+                /* destination */input.op_nftoken_create_offer().destination());
+            break;
+
+        case Proto::SigningInput::kOpNftokenAcceptOffer:
+            transaction.createNFTokenAcceptOffer(/* sell_offer */input.op_nftoken_accept_offer().sell_offer());
+            break;
+
+        case Proto::SigningInput::kOpNftokenCancelOffer: {
+                std::vector<std::string> token_offers;
+                for (int i = 0; i < input.op_nftoken_cancel_offer().token_offers_size(); i++) {
+                    token_offers.push_back(input.op_nftoken_cancel_offer().token_offers(i));
+                }
+
+                transaction.createNFTokenCancelOffer(/* token_offers */token_offers);
+            }
+
+            break;
+
+        case Proto::SigningInput::kOpTrustSet:
+            transaction.createTrustSet(
+                /* currency */input.op_trust_set().limit_amt().currency(),
+                /* value */input.op_trust_set().limit_amt().value(),
+                /* issuer */input.op_trust_set().limit_amt().issuer());
+
+        default:
+            break;
     }
 
-    auto key = PrivateKey(Data(input.private_key().begin(), input.private_key().end()));
-    auto transaction = Transaction(
-        /* amount */ input.amount(),
-        /* fee */ input.fee(),
-        /* flags */ input.flags(),
-        /* sequence */ input.sequence(),
-        /* last_ledger_sequence */ input.last_ledger_sequence(),
-        /* account */ Address(input.account()),
-        /* destination */ input.destination(),
-        /* destination_tag*/ tag);
-
     auto signer = Signer();
+    auto key = PrivateKey(Data(input.private_key().begin(), input.private_key().end()));
     signer.sign(key, transaction);
 
     auto encoded = transaction.serialize();
     output.set_encoded(encoded.data(), encoded.size());
+
     return output;
 }
 
 void Signer::sign(const PrivateKey& privateKey, Transaction& transaction) const noexcept {
     /// See https://github.com/trezor/trezor-core/blob/master/src/apps/ripple/sign_tx.py#L59
-    transaction.flags |= fullyCanonical;
+    //transaction.flags |= fullyCanonical; // deprecated
     transaction.pub_key = privateKey.getPublicKey(TWPublicKeyTypeSECP256k1).bytes;
 
     auto unsignedTx = transaction.getPreImage();

--- a/src/XRP/Signer.cpp
+++ b/src/XRP/Signer.cpp
@@ -10,7 +10,6 @@
 
 namespace TW::Ripple {
 
-//static const int64_t fullyCanonical = 0x80000000; // deprecated
 
 Proto::SigningOutput Signer::sign(const Proto::SigningInput& input) noexcept {
     auto output = Proto::SigningOutput();

--- a/src/XRP/Signer.cpp
+++ b/src/XRP/Signer.cpp
@@ -16,77 +16,47 @@ Proto::SigningOutput Signer::sign(const Proto::SigningInput& input) noexcept {
 
     auto transaction =
         Transaction(
-            /* fee */input.fee(),
-            /* flags */input.flags(),
-            /* sequence */input.sequence(),
-            /* last_ledger_sequence */input.last_ledger_sequence(),
-            /* account */Address(input.account()));
+            input.fee(),
+            input.flags(),
+            input.sequence(),
+            input.last_ledger_sequence(),
+            Address(input.account()));
     switch (input.operation_oneof_case()) {
-        case Proto::SigningInput::kOpPayment: {
-            const int64_t tag = input.op_payment().destination_tag();
-            if (tag > std::numeric_limits<uint32_t>::max() || tag < 0) {
-                output.set_error(Common::Proto::SigningError::Error_invalid_memo);
-                return output;
-            }
-
-            switch (input.op_payment().amount_oneof_case()) {
-                case Proto::OperationPayment::kAmount:
-                    transaction.createXrpPayment(
-                        /* amount */input.op_payment().amount(),
-                        /* destination */input.op_payment().destination(),
-                        /* destination_tag*/tag);
-                    break;
-
-                case Proto::OperationPayment::kCurrencyAmt:
-                    transaction.createTokenPayment(
-                        /* currency */input.op_payment().currency_amt().currency(),
-                        /* value */input.op_payment().currency_amt().value(),
-                        /* issuer */input.op_payment().currency_amt().issuer(),
-                        /* destination */input.op_payment().destination(),
-                        /* destination_tag*/tag);
-                    break;
-
-                default:
-                    break;
-            }
-
+        case Proto::SigningInput::kOpPayment:
+            signPayment(input, output, transaction);
             break;
-        }
 
         case Proto::SigningInput::kOpNftokenBurn:
-            transaction.createNFTokenBurn(
-                /* nftoken_id */input.op_nftoken_burn().nftoken_id());
+            transaction.createNFTokenBurn(input.op_nftoken_burn().nftoken_id());
             break;
 
         case Proto::SigningInput::kOpNftokenCreateOffer:
             transaction.createNFTokenCreateOffer(
-                /* token_id */input.op_nftoken_create_offer().nftoken_id(),
-                /* destination */input.op_nftoken_create_offer().destination());
+                input.op_nftoken_create_offer().nftoken_id(),
+                input.op_nftoken_create_offer().destination());
             break;
 
         case Proto::SigningInput::kOpNftokenAcceptOffer:
-            transaction.createNFTokenAcceptOffer(/* sell_offer */input.op_nftoken_accept_offer().sell_offer());
+            transaction.createNFTokenAcceptOffer(input.op_nftoken_accept_offer().sell_offer());
             break;
 
-        case Proto::SigningInput::kOpNftokenCancelOffer: {
-                std::vector<std::string> token_offers;
-                for (int i = 0; i < input.op_nftoken_cancel_offer().token_offers_size(); i++) {
-                    token_offers.push_back(input.op_nftoken_cancel_offer().token_offers(i));
-                }
-
-                transaction.createNFTokenCancelOffer(/* token_offers */token_offers);
-            }
-
+        case Proto::SigningInput::kOpNftokenCancelOffer:
+            signNfTokenCancelOffer(input, transaction);
             break;
 
         case Proto::SigningInput::kOpTrustSet:
             transaction.createTrustSet(
-                /* currency */input.op_trust_set().limit_amt().currency(),
-                /* value */input.op_trust_set().limit_amt().value(),
-                /* issuer */input.op_trust_set().limit_amt().issuer());
+                input.op_trust_set().limit_amount().currency(),
+                input.op_trust_set().limit_amount().value(),
+                input.op_trust_set().limit_amount().issuer());
+            break;
 
         default:
             break;
+    }
+
+    if (output.error()) {
+        return output;
     }
 
     auto signer = Signer();
@@ -108,6 +78,46 @@ void Signer::sign(const PrivateKey& privateKey, Transaction& transaction) const 
     auto half = Data(hash.begin(), hash.begin() + 32);
 
     transaction.signature = privateKey.signAsDER(half);
+}
+
+void Signer::signPayment(const Proto::SigningInput& input,
+                         Proto::SigningOutput& output,
+                         Transaction& transaction) noexcept {
+    const int64_t tag = input.op_payment().destination_tag();
+    if (tag > std::numeric_limits<uint32_t>::max() || tag < 0) {
+        output.set_error(Common::Proto::SigningError::Error_invalid_memo);
+        return;
+    }
+
+    switch (input.op_payment().amount_oneof_case()) {
+        case Proto::OperationPayment::kAmount:
+            transaction.createXrpPayment(
+                input.op_payment().amount(),
+                input.op_payment().destination(),
+                tag);
+            break;
+
+        case Proto::OperationPayment::kCurrencyAmount:
+            transaction.createTokenPayment(
+                input.op_payment().currency_amount().currency(),
+                input.op_payment().currency_amount().value(),
+                input.op_payment().currency_amount().issuer(),
+                input.op_payment().destination(),
+                tag);
+            break;
+
+        default:
+            break;
+    }
+}
+
+void Signer::signNfTokenCancelOffer(const Proto::SigningInput& input, Transaction& transaction) noexcept {
+    std::vector<std::string> token_offers;
+    for (int i = 0; i < input.op_nftoken_cancel_offer().token_offers_size(); i++) {
+        token_offers.emplace_back(input.op_nftoken_cancel_offer().token_offers(i));
+    }
+
+    transaction.createNFTokenCancelOffer(token_offers);
 }
 
 } // namespace TW::Ripple

--- a/src/XRP/Signer.h
+++ b/src/XRP/Signer.h
@@ -21,6 +21,13 @@ class Signer {
 
     /// Signs the given transaction.
     void sign(const PrivateKey& privateKey, Transaction& transaction) const noexcept;
+
+  private:
+    static void signPayment(const Proto::SigningInput& input,
+                     Proto::SigningOutput& output,
+                     Transaction& transaction) noexcept;
+
+    static void signNfTokenCancelOffer(const Proto::SigningInput& input, Transaction& transaction) noexcept;
 };
 
 } // namespace TW::Ripple

--- a/src/XRP/Transaction.cpp
+++ b/src/XRP/Transaction.cpp
@@ -9,55 +9,104 @@
 #include "../BinaryCoding.h"
 
 #include <algorithm>
+#include <cmath>
+#include <sstream>
+#include <string>
 
 namespace TW::Ripple {
 
 const int NETWORK_PREFIX = 0x53545800;
 
 Data Transaction::serialize() const {
+	// See https://xrpl.org/serialization.html
+
     auto data = Data();
+
     /// field must be sorted by field type then by field name
     /// "type"
     encodeType(FieldType::int16, 2, data);
-    encode16BE(uint16_t(TransactionType::payment), data);
+    encode16BE(uint16_t(transaction_type), data);
+
     /// "flags"
     encodeType(FieldType::int32, 2, data);
     encode32BE(static_cast<uint32_t>(flags), data);
+
     /// "sequence"
     encodeType(FieldType::int32, 4, data);
     encode32BE(sequence, data);
+
     /// "destinationTag"
-    if (encode_tag) {
+    if ((transaction_type == TransactionType::payment) && encode_tag) {
         encodeType(FieldType::int32, 14, data);
         encode32BE(static_cast<uint32_t>(destination_tag), data);
     }
+
     /// "lastLedgerSequence"
     if (last_ledger_sequence > 0) {
         encodeType(FieldType::int32, 27, data);
         encode32BE(last_ledger_sequence, data);
     }
+
+    /// "NFTokenId"
+    if ((transaction_type == TransactionType::NFTokenCreateOffer) ||
+        (transaction_type == TransactionType::NFTokenBurn)) {
+        encodeType(FieldType::hash256, 10, data);
+        data.insert(data.end(), nftoken_id.begin(), nftoken_id.end());
+    }
+
+    /// "NFTokenAcceptOffer"
+    if (transaction_type == TransactionType::NFTokenAcceptOffer) {
+        encodeType(FieldType::hash256, 29, data);
+        data.insert(data.end(), sell_offer.begin(), sell_offer.end());
+    }
+
     /// "amount"
-    encodeType(FieldType::amount, 1, data);
-    append(data, serializeAmount(amount));
+    if ((transaction_type == TransactionType::payment) ||
+        (transaction_type == TransactionType::NFTokenCreateOffer)) {
+        encodeType(FieldType::amount, 1, data);
+        append(data,
+               (currency_amt.currency.size() > 0) ?
+                 serializeCurrencyAmt(currency_amt) :
+                 serializeAmount(amount));
+    } else if (transaction_type == TransactionType::TrustSet) {
+        encodeType(FieldType::amount, 3, data);
+        append(data, serializeCurrencyAmt(limit_amt));
+    }
+
     /// "fee"
     encodeType(FieldType::amount, 8, data);
     append(data, serializeAmount(fee));
+
     /// "signingPubKey"
     if (!pub_key.empty()) {
         encodeType(FieldType::vl, 3, data);
         encodeBytes(pub_key, data);
     }
+
     /// "txnSignature"
     if (!signature.empty()) {
         encodeType(FieldType::vl, 4, data);
         encodeBytes(signature, data);
     }
+
     /// "account"
     encodeType(FieldType::account, 1, data);
     encodeBytes(serializeAddress(account), data);
+
     /// "destination"
-    encodeType(FieldType::account, 3, data);
-    encodeBytes(destination, data);
+    if ((transaction_type == TransactionType::payment) ||
+        (transaction_type == TransactionType::NFTokenCreateOffer)) {
+        encodeType(FieldType::account, 3, data);
+        encodeBytes(destination, data);
+    }
+
+    /// "NFTokenOffers"
+    if (transaction_type == TransactionType::NFTokenCancelOffer) {
+        // only support one offer
+        encodeType(FieldType::vector256, 4, data);
+        encodeBytes(token_offers, data);
+    }
+
     return data;
 }
 
@@ -78,6 +127,106 @@ Data Transaction::serializeAmount(int64_t amount) {
     data[0] &= 0x7F;
     /// set second bit to indicate positive number
     data[0] |= 0x40;
+    return data;
+}
+
+Data Transaction::serializeCurrencyAmt(const CurrencyAmt& currency_amt) {
+    // Calculate value
+    // https://xrpl.org/serialization.html#token-amount-format
+    int64_t sign = 0;
+    int64_t mantissa = 0;
+    int32_t exp = 0;
+    try {
+        // double stores 52-bit mantissa but ripple stores 54-bit mantissa
+        // can parse to boost::multiprecision::float128_t but needs quadmath.h
+        int32_t num_after_dot = 0;
+        bool after_dot = false;
+        bool after_e = false;
+        bool has_exp = false;
+        std::ostringstream mantissa_oss, exp_oss;
+        for (auto i : currency_amt.value) {
+            if (i == '.') {
+                after_dot = true;
+            } else if (i == 'e') {
+                after_dot = false;
+                after_e = true;
+            } else if (after_e) {
+                has_exp = true;
+                exp_oss << i;
+            } else {
+                mantissa_oss << i;
+                if (after_dot) {
+                    num_after_dot++;
+                }
+            }
+        }
+
+        mantissa = std::stoll(mantissa_oss.str());
+        sign = (mantissa >= 0) ? 1 : 0;
+        mantissa = (mantissa < 0) ? (mantissa * -1) : mantissa;
+
+        exp = has_exp ? std::stoi(exp_oss.str()) : 0;
+        exp -= num_after_dot;
+    } catch (const std::exception& e) {
+        return Data();
+    }
+
+    int64_t min_mantissa = (uint64_t)pow(10, 15);
+    int64_t max_mantissa = (uint64_t)pow(10, 16) - 1;
+    int32_t min_exp = -96;
+    int32_t max_exp = 80;
+
+    while ((mantissa < min_mantissa) && (exp > min_exp)) {
+        mantissa *= 10;
+        exp--;
+    }
+
+    while (mantissa > max_mantissa) {
+        if (exp >= max_exp) {
+            return Data();
+        }
+
+        mantissa /= 10;
+        exp++;
+    }
+
+    if (((exp < min_exp) || (mantissa < min_mantissa)) ||
+        ((exp > max_exp) || (mantissa > max_mantissa))) {
+        return Data();
+    }
+
+    typedef union {
+        uint64_t value;
+        struct {
+            uint64_t mantissa : 54;
+            uint64_t exp : 8;
+            uint64_t sign : 1;
+            uint64_t not_xrp : 1;
+        } parts;
+    } amt_cast;
+
+    amt_cast ac;
+    ac.parts.mantissa = mantissa;
+    ac.parts.exp = exp + 97;
+    ac.parts.sign = sign;
+    ac.parts.not_xrp = 1;
+
+    // Serialize fields
+	// https://xrpl.org/serialization.html#amount-fields
+    auto data = Data();
+    encode64BE(ac.value, data);
+
+    // ISO-4217 currency code
+    encode0(1, data); // type code (0x00)
+    encode0(11, data); // reserved
+    if (currency_amt.currency.size() == 3) {
+        data.insert(data.end(), currency_amt.currency.begin(), currency_amt.currency.end());
+    } else {
+        encode0(3, data); // none
+    }
+
+    encode0(5, data); // reserved
+    data.insert(data.end(), currency_amt.issuer.begin(), currency_amt.issuer.end());
     return data;
 }
 

--- a/src/XRP/Transaction.h
+++ b/src/XRP/Transaction.h
@@ -45,15 +45,15 @@ class Transaction {
     /// Float and negative amounts are not supported.
     /// See https://github.com/trezor/trezor-core/tree/master/src/apps/ripple#transactions
   public:
-      struct CurrencyAmt {
+      struct CurrencyAmount {
         Data currency;
         Data value;
         Data issuer;
     };
 
     int64_t amount;
-    CurrencyAmt currency_amt;
-    CurrencyAmt limit_amt;
+    CurrencyAmount currency_amount;
+    CurrencyAmount limit_amount;
     int64_t fee;
     int64_t flags;
     int32_t sequence;
@@ -98,14 +98,14 @@ class Transaction {
 
     void createTrustSet(const std::string& currency, const std::string& value, const std::string& issuer) {
         transaction_type = TransactionType::TrustSet;
-        setCurrencyAmt(limit_amt, currency, value, issuer);
+        setCurrencyAmount(limit_amount, currency, value, issuer);
     }
 
     void createTokenPayment(const std::string& currency, const std::string& value, const std::string& issuer,
                             const std::string& p_destination, int64_t p_destination_tag) {
         transaction_type = TransactionType::payment;
         setDestination(p_destination, p_destination_tag);
-        setCurrencyAmt(currency_amt, currency, value, issuer);
+        setCurrencyAmount(currency_amount, currency, value, issuer);
     }
 
     void createNFTokenBurn(const std::string& p_nftoken_id) {
@@ -140,14 +140,14 @@ class Transaction {
     Data getPreImage() const;
 
     static Data serializeAmount(int64_t amount);
-    static Data serializeCurrencyAmt(const CurrencyAmt& currency_amt);
+    static Data serializeCurrencyAmount(const CurrencyAmount& currency_amount);
     static Data serializeAddress(Address address);
 
   private:
-    void setCurrencyAmt(CurrencyAmt& p_currency_amt, const std::string& currency, const std::string& value, const std::string& issuer) {
-        p_currency_amt.currency = Data(currency.begin(), currency.end());
-        p_currency_amt.value = Data(value.begin(), value.end());
-        setAccount(issuer, p_currency_amt.issuer);
+    void setCurrencyAmount(CurrencyAmount& p_currency_amount, const std::string& currency, const std::string& value, const std::string& issuer) {
+        p_currency_amount.currency = Data(currency.begin(), currency.end());
+        p_currency_amount.value = Data(value.begin(), value.end());
+        setAccount(issuer, p_currency_amount.issuer);
     }
 
     void setDestination(const std::string& p_destination, int64_t p_destination_tag) {

--- a/src/XRP/Transaction.h
+++ b/src/XRP/Transaction.h
@@ -10,25 +10,50 @@
 #include "XAddress.h"
 #include "Data.h"
 #include "../proto/Ripple.pb.h"
+#include "../HexCoding.h"
 
 namespace TW::Ripple {
 
+// See https://github.com/XRPLF/rippled/blob/master/src/ripple/protocol/SField.h#L57-L74
 enum class FieldType: int {
-    int16   = 1,
-    int32   = 2,
-    amount  = 6,
-    vl      = 7,
-    account = 8
+    int16     = 1,
+    int32     = 2,
+    hash256   = 5,
+    amount    = 6,
+    vl        = 7,
+    account   = 8,
+    vector256 = 19
 };
 
-enum class TransactionType { payment = 0 };
+// See https://github.com/XRPLF/xrpl.js/blob/main/packages/ripple-binary-codec/src/enums/definitions.json
+enum class TransactionType {
+    no_type = -1,
+    payment = 0,
+    TrustSet = 20,
+    NFTokenBurn = 26,
+    NFTokenCreateOffer = 27,
+    NFTokenCancelOffer = 28,
+    NFTokenAcceptOffer = 29
+};
+
+// See https://xrpl.org/nftokencreateoffer.html
+enum class NFTokenCreateOfferFlags: int64_t {
+    tfSellNFToken = 0x00000001
+};
 
 class Transaction {
-    /// We only support transaction types other than the Payment transaction.
-    /// Non-XRP currencies are not supported. Float and negative amounts are not supported.
+    /// Float and negative amounts are not supported.
     /// See https://github.com/trezor/trezor-core/tree/master/src/apps/ripple#transactions
   public:
+      struct CurrencyAmt {
+        Data currency;
+        Data value;
+        Data issuer;
+    };
+
     int64_t amount;
+    CurrencyAmt currency_amt;
+    CurrencyAmt limit_amt;
     int64_t fee;
     int64_t flags;
     int32_t sequence;
@@ -39,28 +64,74 @@ class Transaction {
     int64_t destination_tag;
     Data pub_key;
     Data signature;
+    Data nftoken_id;
+    Data sell_offer;
+    Data token_offers;
+    TransactionType transaction_type;
 
-    Transaction(int64_t amount, int64_t fee, int64_t flags, int32_t sequence,
-                int32_t last_ledger_sequence, Address account, const std::string& destination,
-                int64_t destination_tag)
-        : amount(amount)
+    Transaction(int64_t fee, int64_t flags, int32_t sequence, int32_t last_ledger_sequence, Address p_account)
+        : amount(0)
         , fee(fee)
         , flags(flags)
         , sequence(sequence)
         , last_ledger_sequence(last_ledger_sequence)
-        , account(account) {
-          try {
-            auto address = Address(destination);
-            encode_tag = destination_tag > 0;
-            this->destination_tag = destination_tag;
-            this->destination = Data(address.bytes.begin() + 1, address.bytes.end());
-          } catch(const std::exception& e) {
-            auto xAddress = XAddress(destination);
-            encode_tag = xAddress.flag != TagFlag::none;
-            this->destination_tag = xAddress.tag;
-            this->destination = Data(xAddress.bytes.begin(), xAddress.bytes.end());
-          }
+        , account(p_account)
+        , encode_tag(false)
+        , destination_tag(0)
+        , nftoken_id(0)
+        , sell_offer(0)
+        , token_offers(0)
+        , transaction_type(TransactionType::no_type) {}
+
+    void createXrpPayment(int64_t p_amount, const std::string& p_destination, int64_t p_destination_tag) {
+        transaction_type = TransactionType::payment;
+        amount = p_amount;
+        setDestination(p_destination, p_destination_tag);
+    }
+
+    void createTrustSet(const std::string& currency, const std::string& issuer) { 
+        // Use maximum amount
+        // https://xrpl.org/currency-formats.html
+        std::string value("9999999999999999e80");
+        createTrustSet(currency, value, issuer);
+    }
+
+    void createTrustSet(const std::string& currency, const std::string& value, const std::string& issuer) {
+        transaction_type = TransactionType::TrustSet;
+        setCurrencyAmt(limit_amt, currency, value, issuer);
+    }
+
+    void createTokenPayment(const std::string& currency, const std::string& value, const std::string& issuer,
+                            const std::string& p_destination, int64_t p_destination_tag) {
+        transaction_type = TransactionType::payment;
+        setDestination(p_destination, p_destination_tag);
+        setCurrencyAmt(currency_amt, currency, value, issuer);
+    }
+
+    void createNFTokenBurn(const std::string& p_nftoken_id) {
+        transaction_type = TransactionType::NFTokenBurn;
+        nftoken_id = parse_hex(p_nftoken_id);
+    }
+
+    void createNFTokenCreateOffer(const std::string& p_nftoken_id, const std::string& p_destination) {
+        transaction_type = TransactionType::NFTokenCreateOffer;
+        flags = int64_t(NFTokenCreateOfferFlags::tfSellNFToken);
+        nftoken_id = parse_hex(p_nftoken_id);
+        setAccount(p_destination, destination);
+    }
+
+    void createNFTokenAcceptOffer(const std::string& p_sell_offer) {
+        transaction_type = TransactionType::NFTokenAcceptOffer;
+        sell_offer = parse_hex(p_sell_offer);
+    }
+
+    void createNFTokenCancelOffer(const std::vector<std::string> p_token_offers) {
+        transaction_type = TransactionType::NFTokenCancelOffer;
+        for (auto i : p_token_offers) {
+            Data token_offer = parse_hex(i);
+            token_offers.insert(token_offers.end(), token_offer.begin(), token_offer.end());
         }
+    }
 
   public:
     /// simplified serialization format tailored for Payment transaction type
@@ -69,7 +140,39 @@ class Transaction {
     Data getPreImage() const;
 
     static Data serializeAmount(int64_t amount);
+    static Data serializeCurrencyAmt(const CurrencyAmt& currency_amt);
     static Data serializeAddress(Address address);
+
+  private:
+    void setCurrencyAmt(CurrencyAmt& p_currency_amt, const std::string& currency, const std::string& value, const std::string& issuer) {
+        p_currency_amt.currency = Data(currency.begin(), currency.end());
+        p_currency_amt.value = Data(value.begin(), value.end());
+        setAccount(issuer, p_currency_amt.issuer);
+    }
+
+    void setDestination(const std::string& p_destination, int64_t p_destination_tag) {
+        try {
+            auto address = Address(p_destination);
+            encode_tag = p_destination_tag > 0;
+            destination_tag = p_destination_tag;
+            destination = Data(address.bytes.begin() + 1, address.bytes.end());
+        } catch(const std::exception& e) {
+            auto xAddress = XAddress(p_destination);
+            encode_tag = xAddress.flag != TagFlag::none;
+            destination_tag = xAddress.tag;
+            destination = Data(xAddress.bytes.begin(), xAddress.bytes.end());
+        }
+    }
+
+    void setAccount(const std::string& p_account, Data& data) {
+        try {
+            auto address = Address(p_account);
+            data = Data(address.bytes.begin() + 1, address.bytes.end());
+        } catch(const std::exception& e) {
+            auto xAddress = XAddress(p_account);
+            data = Data(xAddress.bytes.begin(), xAddress.bytes.end());
+        }
+    }
 };
 
 } // namespace TW::Ripple

--- a/src/proto/Ripple.proto
+++ b/src/proto/Ripple.proto
@@ -22,7 +22,7 @@ message CurrencyAmount {
 
 // https://xrpl.org/trustset.html
 message OperationTrustSet {
-    CurrencyAmount limit_amt = 1;
+    CurrencyAmount limit_amount = 1;
 }
 
 // https://xrpl.org/payment.html
@@ -30,7 +30,7 @@ message OperationPayment {
     // Transfer amount
 	oneof amount_oneof {
 		int64 amount = 1;
-		CurrencyAmount currency_amt = 2;
+		CurrencyAmount currency_amount = 2;
 	}
 
     // Target account
@@ -42,29 +42,29 @@ message OperationPayment {
 
 // https://xrpl.org/nftokenburn.html 
 message OperationNFTokenBurn {
-  // Hash256 NFTokenId
-  bytes nftoken_id = 1;
+    // Hash256 NFTokenId
+    bytes nftoken_id = 1;
 }
 
 // https://xrpl.org/nftokencreateoffer.html 
 message OperationNFTokenCreateOffer {
-  // Hash256 NFTokenId
-  bytes nftoken_id = 1;
+    // Hash256 NFTokenId
+    bytes nftoken_id = 1;
 
-  // Destination account
-  string destination = 2;
+    // Destination account
+    string destination = 2;
 }
 
 // https://xrpl.org/nftokenacceptoffer.html 
 message OperationNFTokenAcceptOffer {
-  // Hash256 NFTokenOffer
-  bytes sell_offer = 1;
+    // Hash256 NFTokenOffer
+    bytes sell_offer = 1;
 }
 
 // https://xrpl.org/nftokencanceloffer.html 
 message OperationNFTokenCancelOffer {
-  // Vector256 NFTokenOffers
-  repeated bytes token_offers = 1;
+    // Vector256 NFTokenOffers
+    repeated bytes token_offers = 1;
 }
 
 // Input data necessary to create a signed transaction.

--- a/src/proto/Ripple.proto
+++ b/src/proto/Ripple.proto
@@ -5,34 +5,101 @@ option java_package = "wallet.core.jni.proto";
 
 import "Common.proto";
 
-// Input data necessary to create a signed transaction.
-message SigningInput {
+// https://xrpl.org/currency-formats.html#token-amounts
+message CurrencyAmount {
+	// Currency code
+	// https://xrpl.org/currency-formats.html#currency-codes
+	string currency = 1;
+
+	// String number
+	// https://xrpl.org/currency-formats.html#string-numbers
+	string value = 2;
+
+	// Account
+	// https://xrpl.org/accounts.html
+	string issuer = 3;
+}
+
+// https://xrpl.org/trustset.html
+message OperationTrustSet {
+    CurrencyAmount limit_amt = 1;
+}
+
+// https://xrpl.org/payment.html
+message OperationPayment {
     // Transfer amount
-    int64 amount = 1;
-
-    // Transfer fee
-    int64 fee = 2;
-
-    // Account sequence number
-    int32 sequence = 3;
-
-    // Ledger sequence number
-    int32 last_ledger_sequence = 4;
-
-    // Source account
-    string account = 5;
+	oneof amount_oneof {
+		int64 amount = 1;
+		CurrencyAmount currency_amt = 2;
+	}
 
     // Target account
-    string destination = 6;
+	string destination = 3;
 
     // A Destination Tag
-    int64 destination_tag = 7;
+	int64 destination_tag = 4;
+}
+
+// https://xrpl.org/nftokenburn.html 
+message OperationNFTokenBurn {
+  // Hash256 NFTokenId
+  bytes nftoken_id = 1;
+}
+
+// https://xrpl.org/nftokencreateoffer.html 
+message OperationNFTokenCreateOffer {
+  // Hash256 NFTokenId
+  bytes nftoken_id = 1;
+
+  // Destination account
+  string destination = 2;
+}
+
+// https://xrpl.org/nftokenacceptoffer.html 
+message OperationNFTokenAcceptOffer {
+  // Hash256 NFTokenOffer
+  bytes sell_offer = 1;
+}
+
+// https://xrpl.org/nftokencanceloffer.html 
+message OperationNFTokenCancelOffer {
+  // Vector256 NFTokenOffers
+  repeated bytes token_offers = 1;
+}
+
+// Input data necessary to create a signed transaction.
+message SigningInput {
+    // Transfer fee
+    int64 fee = 1;
+
+    // Account sequence number
+    int32 sequence = 2;
+
+    // Ledger sequence number
+    int32 last_ledger_sequence = 3;
+
+    // Source account
+    string account = 4;
 
     // Transaction flags, optional
-    int64 flags = 8;
+    int64 flags = 5;
 
     // The secret private key used for signing (32 bytes).
-    bytes private_key = 9;
+    bytes private_key = 6;
+
+    oneof operation_oneof {
+        OperationTrustSet op_trust_set = 7;
+
+        OperationPayment op_payment = 8;
+
+        OperationNFTokenBurn op_nftoken_burn = 9;
+
+        OperationNFTokenCreateOffer op_nftoken_create_offer = 10;
+
+        OperationNFTokenAcceptOffer op_nftoken_accept_offer = 11;
+
+        OperationNFTokenCancelOffer op_nftoken_cancel_offer = 12;
+    }
 }
 
 // Result containing the signed and encoded transaction.

--- a/swift/Tests/Blockchains/RippleTests.swift
+++ b/swift/Tests/Blockchains/RippleTests.swift
@@ -29,25 +29,33 @@ class RippleTests: XCTestCase {
     }
 
     func testSigner() {
-        let input = RippleSigningInput.with {
-            $0.amount = 29_000_000
-            $0.fee = 200_000
-            $0.sequence = 1 // from account info api
-            $0.account = "rDpysuumkweqeC7XdNgYNtzL5GxbdsmrtF"
+        let operation = RippleOperationPayment.with {
             $0.destination = "rU893viamSnsfP3zjzM2KPxjqZjXSXK6VF"
-            $0.privateKey = Data(hexString: "ba005cd605d8a02e3d5dfd04234cef3a3ee4f76bfbad2722d1fb5af8e12e6764")!
+            $0.amount = 10
+        }
+        let input = RippleSigningInput.with {
+            $0.fee = 10
+            $0.sequence = 32268248 // from account info api
+            $0.lastLedgerSequence = 32268269
+            $0.account = "rfxdLwsZnoespnTDDb1Xhvbc8EFNdztaoq"
+            $0.privateKey = Data(hexString: "a5576c0f63da10e584568c8d134569ff44017b0a249eb70657127ae04f38cc77")!
+            $0.opPayment = operation
         }
 
         let output: RippleSigningOutput = AnySigner.sign(input: input, coin: .xrp)
-        XCTAssertEqual(output.encoded.hexString, "12000022800000002400000001614000000001ba8140684000000000030d407321026cc34b92cefb3a4537b3edb0b6044c04af27c01583c577823ecc69a9a21119b6744630440220067f20b3eebfc7107dd0bcc72337a236ac3be042c0469f2341d76694a17d4bb9022048393d7ee7dcb729783b33f5038939ddce1bb8337e66d752974626854556bbb681148400b6b6d08d5d495653d73eda6804c249a5148883148132e4e20aecf29090ac428a9c43f230a829220d")
+        XCTAssertEqual(output.encoded.hexString, "12000022000000002401ec5fd8201b01ec5fed61400000000000000a68400000000000000a732103d13e1152965a51a4a9fd9a8b4ea3dd82a4eba6b25fcad5f460a2342bb650333f74463044022037d32835c9394f39b2cfd4eaf5b0a80e0db397ace06630fa2b099ff73e425dbc02205288f780330b7a88a1980fa83c647b5908502ad7de9a44500c08f0750b0d9e8481144c55f5a78067206507580be7bb2686c8460adff983148132e4e20aecf29090ac428a9c43f230a829220d")
 
-        let input2 = RippleSigningInput.with {
-            $0.amount = 29_000_000
-            $0.fee = 200_000
-            $0.sequence = 1 // from account info api
-            $0.account = "rDpysuumkweqeC7XdNgYNtzL5GxbdsmrtF"
+        let operation2 = RippleOperationPayment.with {
             $0.destination = "XVfvixWZQKkcenFRYApCjpTUyJ4BePMjMaPqnob9QVPiVJV"
-            $0.privateKey = Data(hexString: "ba005cd605d8a02e3d5dfd04234cef3a3ee4f76bfbad2722d1fb5af8e12e6764")!
+            $0.amount = 10
+        }
+        let input2 = RippleSigningInput.with {
+            $0.fee = 10
+            $0.sequence = 32268248 // from account info api
+            $0.lastLedgerSequence = 32268269
+            $0.account = "rfxdLwsZnoespnTDDb1Xhvbc8EFNdztaoq"
+            $0.privateKey = Data(hexString: "a5576c0f63da10e584568c8d134569ff44017b0a249eb70657127ae04f38cc77")!
+            $0.opPayment = operation
         }
         let output2: RippleSigningOutput = AnySigner.sign(input: input2, coin: .xrp)
         XCTAssertEqual(output2.encoded, output.encoded)

--- a/tests/chains/XRP/TWAnySignerTests.cpp
+++ b/tests/chains/XRP/TWAnySignerTests.cpp
@@ -43,14 +43,33 @@ TEST(TWAnySignerRipple, SignXrpPayment) {
     EXPECT_EQ(output.encoded(), "");
 }
 
+TEST(TWAnySignerRipple, SignXrpPaymentMain) {
+    // https://xrpscan.com/tx/4B9D022E8C77D798B7D11C41FDFDCF468F03A5564151C520EECA1E96FF1A1610
+    auto key = parse_hex("acf1bbf6264e699da0cc65d17ac03fcca6ded1522d19529df7762db46097ff9f");
+    Proto::SigningInput input;
+
+    input.mutable_op_payment()->set_amount(1000000);
+    input.set_fee(10);
+    input.set_sequence(75674534);
+    input.set_last_ledger_sequence(75674797);
+    input.set_account("rGV1v1xw23PHcRn4Km4tF8R2mfh6yTZkcP");
+    input.mutable_op_payment()->set_destination("rNLpgsBTCwiaZAnHe2ZViAN1GcXZtYW6rg");
+    input.set_private_key(key.data(), key.size());
+
+    Proto::SigningOutput output;
+    ANY_SIGN(input, TWCoinTypeXRP);
+
+    EXPECT_EQ(hex(output.encoded()), "1200002200000000240482b3a6201b0482b4ad6140000000000f424068400000000000000a7321027efc5f15071d2ae5e73ee09a0c17456c5d9170a41d67e3297c554829199be80b74473045022100e1c746c3aeebc8278c627ee4c2ce5cae97e3856292c7fe5388f803920230a37b02207d2eccb76cd35dd379d6b24c2cabd786e62d34a564cf083e863176109c5b6bb48114aa000c09c692ef1f82787e51e22833149941ea2083149232ef60695add51f0f84534cc4084e4fdfc698e");
+}
+
 TEST(TWAnySignerRipple, SignTrustSetPayment) {
     // https://testnet.xrpl.org/transactions/31042345374CFF785B3F7E2A3716E3BAB7E2CAA30D40F5E488E67ABA116655B9
     auto key = parse_hex("8753e78ee2963f301f82e5eeab2754f593fc242ce94273dd2fb0684e3b0f2b91");
     Proto::SigningInput input;
 
-    input.mutable_op_trust_set()->mutable_limit_amt()->set_currency("USD");
-    input.mutable_op_trust_set()->mutable_limit_amt()->set_value("10");
-    input.mutable_op_trust_set()->mutable_limit_amt()->set_issuer("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn");
+    input.mutable_op_trust_set()->mutable_limit_amount()->set_currency("USD");
+    input.mutable_op_trust_set()->mutable_limit_amount()->set_value("10");
+    input.mutable_op_trust_set()->mutable_limit_amount()->set_issuer("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn");
     input.set_fee(10);
     input.set_sequence(32268473);
     input.set_last_ledger_sequence(32268494);
@@ -63,35 +82,37 @@ TEST(TWAnySignerRipple, SignTrustSetPayment) {
     EXPECT_EQ(hex(output.encoded()), "12001422000000002401ec60b9201b01ec60ce63d4c38d7ea4c6800000000000000000000000000055534400000000004b4e9c06f24296074f7bc48f92a97916c6dc5ea968400000000000000a732103dc4a0dae2d550de7cace9c26c1a331a114e3e7efee5577204b476d27e2dc683a7446304402206ebcc7a689845df373dd2566cd3789862d426d9ad4e6a09c2d2772b57e82696a022066b1f217a0f0d834d167613a313f74097423a9ccd11f1ae7f90ffab0d2fc26b58114308ea8e515b64f2e6616a33b42e1bbb9fa00bbd2");
 }
 
-TEST(TWAnySignerRipple, SignTokenPayment) {
+TEST(TWAnySignerRipple, SignTokenPayment0) {
     // https://testnet.xrpl.org/transactions/8F7820892294598B58CFA2E1101D15ED98C179B25A2BA6DAEB4F5B727CB00D4E
-    auto key = parse_hex("4ba5fd2ebf0f5d7e579b3c354c263ebb39cda4093845125786a280301af14e21");
-    Proto::SigningInput input;
+    for (auto value : std::vector({"10", "10e0", "10.0", "10.0e0", "1e1", ".1e2", "0.1e2", "100e-1", "10000000000000000e-15", "0.0000000000000001e17"})) {
+        auto key = parse_hex("4ba5fd2ebf0f5d7e579b3c354c263ebb39cda4093845125786a280301af14e21");
+        Proto::SigningInput input;
 
-    input.mutable_op_payment()->mutable_currency_amt()->set_currency("USD");
-    input.mutable_op_payment()->mutable_currency_amt()->set_value("10");
-    input.mutable_op_payment()->mutable_currency_amt()->set_issuer("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn");
-    input.set_fee(10);
-    input.set_sequence(32268645);
-    input.set_last_ledger_sequence(32268666);
-    input.set_account("raPAA61ca99bdwNiZs5JJukR5rvkHWvkBX");
-    input.mutable_op_payment()->set_destination("rU893viamSnsfP3zjzM2KPxjqZjXSXK6VF");
-    input.set_private_key(key.data(), key.size());
+        input.mutable_op_payment()->mutable_currency_amount()->set_currency("USD");
+        input.mutable_op_payment()->mutable_currency_amount()->set_value("10");
+        input.mutable_op_payment()->mutable_currency_amount()->set_issuer("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn");
+        input.set_fee(10);
+        input.set_sequence(32268645);
+        input.set_last_ledger_sequence(32268666);
+        input.set_account("raPAA61ca99bdwNiZs5JJukR5rvkHWvkBX");
+        input.mutable_op_payment()->set_destination("rU893viamSnsfP3zjzM2KPxjqZjXSXK6VF");
+        input.set_private_key(key.data(), key.size());
 
-    Proto::SigningOutput output;
-    ANY_SIGN(input, TWCoinTypeXRP);
+        Proto::SigningOutput output;
+        ANY_SIGN(input, TWCoinTypeXRP);
 
-    EXPECT_EQ(hex(output.encoded()), "12000022000000002401ec6165201b01ec617a61d4c38d7ea4c6800000000000000000000000000055534400000000004b4e9c06f24296074f7bc48f92a97916c6dc5ea968400000000000000a7321020652a477b0cca8b74d6e68a6a386a836b226101617481b95180eaffbe841b3227446304402203e925caeb05006afb135254e9ae4e46de2019db6c6f68614ef969885063a777602206af110fc29775256fcad8b14974c6a838141d82193192d3b57324fe1079afa1781143b2fa4f36553e5b7a4f54ff9e6883e44b4b0dbb383148132e4e20aecf29090ac428a9c43f230a829220d");
+        EXPECT_EQ(hex(output.encoded()), "12000022000000002401ec6165201b01ec617a61d4c38d7ea4c6800000000000000000000000000055534400000000004b4e9c06f24296074f7bc48f92a97916c6dc5ea968400000000000000a7321020652a477b0cca8b74d6e68a6a386a836b226101617481b95180eaffbe841b3227446304402203e925caeb05006afb135254e9ae4e46de2019db6c6f68614ef969885063a777602206af110fc29775256fcad8b14974c6a838141d82193192d3b57324fe1079afa1781143b2fa4f36553e5b7a4f54ff9e6883e44b4b0dbb383148132e4e20aecf29090ac428a9c43f230a829220d");
+    }
 }
 
-TEST(TWAnySignerRipple, SignTokenPaymentExp) {
+TEST(TWAnySignerRipple, SignTokenPayment1) {
     // https://testnet.xrpl.org/transactions/14606DAAFA54DB29B738000DFC133312B341FFC1D22D57AE0C8D54C9C56E19D8
     auto key = parse_hex("4041882ce8c2ceea6f4cfe1a067b927c1e1eb2f5eb025eaf2f429479a7ec3738");
     Proto::SigningInput input;
 
-    input.mutable_op_payment()->mutable_currency_amt()->set_currency("USD");
-    input.mutable_op_payment()->mutable_currency_amt()->set_value("29.3e-1");
-    input.mutable_op_payment()->mutable_currency_amt()->set_issuer("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn");
+    input.mutable_op_payment()->mutable_currency_amount()->set_currency("USD");
+    input.mutable_op_payment()->mutable_currency_amount()->set_value("29.3e-1");
+    input.mutable_op_payment()->mutable_currency_amount()->set_issuer("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn");
     input.set_fee(10);
     input.set_sequence(32268768);
     input.set_last_ledger_sequence(32268789);

--- a/tests/chains/XRP/TWAnySignerTests.cpp
+++ b/tests/chains/XRP/TWAnySignerTests.cpp
@@ -16,29 +16,166 @@ using namespace TW;
 
 namespace TW::Ripple::tests {
 
-TEST(TWAnySignerRipple, Sign) {
-    auto key = parse_hex("ba005cd605d8a02e3d5dfd04234cef3a3ee4f76bfbad2722d1fb5af8e12e6764");
+TEST(TWAnySignerRipple, SignXrpPayment) {
+    // https://testnet.xrpl.org/transactions/A202034796F37F38D1D20F2025DECECB1623FC801F041FC694199C0D0E49A739
+    auto key = parse_hex("a5576c0f63da10e584568c8d134569ff44017b0a249eb70657127ae04f38cc77");
     Proto::SigningInput input;
 
-    input.set_amount(29000000);
-    input.set_fee(200000);
-    input.set_sequence(1);
-    input.set_account("rDpysuumkweqeC7XdNgYNtzL5GxbdsmrtF");
-    input.set_destination("rU893viamSnsfP3zjzM2KPxjqZjXSXK6VF");
+    input.mutable_op_payment()->set_amount(10);
+    input.set_fee(10);
+    input.set_sequence(32268248);
+    input.set_last_ledger_sequence(32268269);
+    input.set_account("rfxdLwsZnoespnTDDb1Xhvbc8EFNdztaoq");
+    input.mutable_op_payment()->set_destination("rU893viamSnsfP3zjzM2KPxjqZjXSXK6VF");
     input.set_private_key(key.data(), key.size());
 
     Proto::SigningOutput output;
     ANY_SIGN(input, TWCoinTypeXRP);
 
-    EXPECT_EQ(hex(output.encoded()), "12000022800000002400000001614000000001ba8140684000000000030d407321026cc34b92cefb3a4537b3edb0b6044c04af27c01583c577823ecc69a9a21119b6744630440220067f20b3eebfc7107dd0bcc72337a236ac3be042c0469f2341d76694a17d4bb9022048393d7ee7dcb729783b33f5038939ddce1bb8337e66d752974626854556bbb681148400b6b6d08d5d495653d73eda6804c249a5148883148132e4e20aecf29090ac428a9c43f230a829220d");
+    EXPECT_EQ(hex(output.encoded()), "12000022000000002401ec5fd8201b01ec5fed61400000000000000a68400000000000000a732103d13e1152965a51a4a9fd9a8b4ea3dd82a4eba6b25fcad5f460a2342bb650333f74463044022037d32835c9394f39b2cfd4eaf5b0a80e0db397ace06630fa2b099ff73e425dbc02205288f780330b7a88a1980fa83c647b5908502ad7de9a44500c08f0750b0d9e8481144c55f5a78067206507580be7bb2686c8460adff983148132e4e20aecf29090ac428a9c43f230a829220d");
 
     // invalid tag
-    input.set_destination_tag(641505641505);
+    input.mutable_op_payment()->set_destination_tag(641505641505);
 
     ANY_SIGN(input, TWCoinTypeXRP);
 
     EXPECT_EQ(output.error(), Common::Proto::SigningError::Error_invalid_memo);
     EXPECT_EQ(output.encoded(), "");
+}
+
+TEST(TWAnySignerRipple, SignTrustSetPayment) {
+    // https://testnet.xrpl.org/transactions/31042345374CFF785B3F7E2A3716E3BAB7E2CAA30D40F5E488E67ABA116655B9
+    auto key = parse_hex("8753e78ee2963f301f82e5eeab2754f593fc242ce94273dd2fb0684e3b0f2b91");
+    Proto::SigningInput input;
+
+    input.mutable_op_trust_set()->mutable_limit_amt()->set_currency("USD");
+    input.mutable_op_trust_set()->mutable_limit_amt()->set_value("10");
+    input.mutable_op_trust_set()->mutable_limit_amt()->set_issuer("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn");
+    input.set_fee(10);
+    input.set_sequence(32268473);
+    input.set_last_ledger_sequence(32268494);
+    input.set_account("rnRkLPni2Q5yMxSqyJSJEkKUfQNFkaAspS");
+    input.set_private_key(key.data(), key.size());
+
+    Proto::SigningOutput output;
+    ANY_SIGN(input, TWCoinTypeXRP);
+
+    EXPECT_EQ(hex(output.encoded()), "12001422000000002401ec60b9201b01ec60ce63d4c38d7ea4c6800000000000000000000000000055534400000000004b4e9c06f24296074f7bc48f92a97916c6dc5ea968400000000000000a732103dc4a0dae2d550de7cace9c26c1a331a114e3e7efee5577204b476d27e2dc683a7446304402206ebcc7a689845df373dd2566cd3789862d426d9ad4e6a09c2d2772b57e82696a022066b1f217a0f0d834d167613a313f74097423a9ccd11f1ae7f90ffab0d2fc26b58114308ea8e515b64f2e6616a33b42e1bbb9fa00bbd2");
+}
+
+TEST(TWAnySignerRipple, SignTokenPayment) {
+    // https://testnet.xrpl.org/transactions/8F7820892294598B58CFA2E1101D15ED98C179B25A2BA6DAEB4F5B727CB00D4E
+    auto key = parse_hex("4ba5fd2ebf0f5d7e579b3c354c263ebb39cda4093845125786a280301af14e21");
+    Proto::SigningInput input;
+
+    input.mutable_op_payment()->mutable_currency_amt()->set_currency("USD");
+    input.mutable_op_payment()->mutable_currency_amt()->set_value("10");
+    input.mutable_op_payment()->mutable_currency_amt()->set_issuer("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn");
+    input.set_fee(10);
+    input.set_sequence(32268645);
+    input.set_last_ledger_sequence(32268666);
+    input.set_account("raPAA61ca99bdwNiZs5JJukR5rvkHWvkBX");
+    input.mutable_op_payment()->set_destination("rU893viamSnsfP3zjzM2KPxjqZjXSXK6VF");
+    input.set_private_key(key.data(), key.size());
+
+    Proto::SigningOutput output;
+    ANY_SIGN(input, TWCoinTypeXRP);
+
+    EXPECT_EQ(hex(output.encoded()), "12000022000000002401ec6165201b01ec617a61d4c38d7ea4c6800000000000000000000000000055534400000000004b4e9c06f24296074f7bc48f92a97916c6dc5ea968400000000000000a7321020652a477b0cca8b74d6e68a6a386a836b226101617481b95180eaffbe841b3227446304402203e925caeb05006afb135254e9ae4e46de2019db6c6f68614ef969885063a777602206af110fc29775256fcad8b14974c6a838141d82193192d3b57324fe1079afa1781143b2fa4f36553e5b7a4f54ff9e6883e44b4b0dbb383148132e4e20aecf29090ac428a9c43f230a829220d");
+}
+
+TEST(TWAnySignerRipple, SignTokenPaymentExp) {
+    // https://testnet.xrpl.org/transactions/14606DAAFA54DB29B738000DFC133312B341FFC1D22D57AE0C8D54C9C56E19D8
+    auto key = parse_hex("4041882ce8c2ceea6f4cfe1a067b927c1e1eb2f5eb025eaf2f429479a7ec3738");
+    Proto::SigningInput input;
+
+    input.mutable_op_payment()->mutable_currency_amt()->set_currency("USD");
+    input.mutable_op_payment()->mutable_currency_amt()->set_value("29.3e-1");
+    input.mutable_op_payment()->mutable_currency_amt()->set_issuer("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn");
+    input.set_fee(10);
+    input.set_sequence(32268768);
+    input.set_last_ledger_sequence(32268789);
+    input.set_account("raJe5XVt99649qn5Pg7cKdmgEYdN3d4Mky");
+    input.mutable_op_payment()->set_destination("rU893viamSnsfP3zjzM2KPxjqZjXSXK6VF");
+    input.set_private_key(key.data(), key.size());
+
+    Proto::SigningOutput output;
+    ANY_SIGN(input, TWCoinTypeXRP);
+
+    EXPECT_EQ(hex(output.encoded()), "12000022000000002401ec61e0201b01ec61f561d48a68d1c931200000000000000000000000000055534400000000004b4e9c06f24296074f7bc48f92a97916c6dc5ea968400000000000000a73210348c331ab218ba964150490c83875b06ccad2100b1f5707f296764712738cf1ca74473045022100a938783258d33e2e3e6099d1ab68fd85c3fd21adfa00e136a67bed8fddec6c9a02206cc6784c1f212f19dc939207643d361ceaa8334eb366722cf33b24dc7669dd7a81143a2f2f189d05abb8519cc9dee0e2dbc6fa53924183148132e4e20aecf29090ac428a9c43f230a829220d");
+}
+
+TEST(TWAnySignerRipple, SignNfTokenBurn) {
+    // https://devnet.xrpl.org/transactions/37DA90BE3C30016B3A2C3D47D9677278A3F6D4141B318793CE6AA467A6530E2D
+    auto key = parse_hex("7c2ea5c7b1fd7dfc62d879918b7fc779cdff6bf6391d02ec99854297e916318e");
+    Proto::SigningInput input;
+
+    input.mutable_op_nftoken_burn()->set_nftoken_id("000b013a95f14b0044f78a264e41713c64b5f89242540ee208c3098e00000d65");
+    input.set_fee(10);
+    input.set_sequence(22858395);
+    input.set_last_ledger_sequence(22858416);
+    input.set_account("rhR1mTXkg4iSGhz7zsEKBLbV3MkopivPVF");
+    input.set_private_key(key.data(), key.size());
+
+    Proto::SigningOutput output;
+    ANY_SIGN(input, TWCoinTypeXRP);
+
+    EXPECT_EQ(hex(output.encoded()), "12001a220000000024015cca9b201b015ccab05a000b013a95f14b0044f78a264e41713c64b5f89242540ee208c3098e00000d6568400000000000000a73210254fc876043109af1ff11b832320be4436ef51dcc344da5970c9b6c6d1fbcddcf744730450221008b4d437bc92aa4643b275b17c0f88a1bef2c1c160ece5faf93b03e2d31b8278602207640e7e35426352deaafecf61e2b401a4ea1fc645839280370a72fa3c41aea7d8114259cbcf9635360bc302f27d0ce72c18d4dbe9c8d");
+}
+
+TEST(TWAnySignerRipple, SignNfTokenCreateOffer) {
+    // https://devnet.xrpl.org/transactions/E61D66E261DB89CEAAB4F54ECF792B329296CB524E8B40EA99D27CF5E16DD27D
+    auto key = parse_hex("1963884da4a4da79ad7681d106b2c55fb652c68ca7b288dd12bb86cd40b9d940");
+    Proto::SigningInput input;
+
+    input.mutable_op_nftoken_create_offer()->set_nftoken_id("000b013a95f14b0044f78a264e41713c64b5f89242540ee208c3098e00000d65");
+    input.mutable_op_nftoken_create_offer()->set_destination("rDxTa8vhigDUCq9nmZY8jAkFne5XrcYbxG");
+    input.set_fee(10);
+    input.set_sequence(22857522);
+    input.set_last_ledger_sequence(22857543);
+    input.set_account("rJdxtrVoL3Tak74EzN8SdMxFF6RP9smjJJ");
+    input.set_private_key(key.data(), key.size());
+
+    Proto::SigningOutput output;
+    ANY_SIGN(input, TWCoinTypeXRP);
+
+    EXPECT_EQ(hex(output.encoded()), "12001b220000000124015cc732201b015cc7475a000b013a95f14b0044f78a264e41713c64b5f89242540ee208c3098e00000d6561400000000000000068400000000000000a7321022707066e4f8b87b749ef802338be064065dc978f0ea52ea9c8c8ea0a6145571974473045022100a148140469b8e9e2f9aa43631f3101e532d161d49a05e739cd3494ea208bd657022029a9752df3fc0d23b8fdb46d2274e69ab198ce6f373aeb7cdd0d81ab05aff6f48114c177c23ed1f5d175f42fd7970ece74ac18d61c4d83148e1e2ca343165bf30e96abead961f7a34510ad93");
+}
+
+TEST(TWAnySignerRipple, SignNfTokenAcceptOffer) {
+    // https://devnet.xrpl.org/transactions/6BB00A7BABB8797D60E3AB0E52DB64562524D014833977D87B04CA9FA3F56AD7
+    auto key = parse_hex("3c01b3458d2b2a4b86a5699d11682d791b5c3136692c5594f7a8ca7f3967e7ae");
+    Proto::SigningInput input;
+
+    input.mutable_op_nftoken_accept_offer()->set_sell_offer("000b013a95f14b0044f78a264e41713c64b5f89242540ee208c3098e00000d65");
+    input.set_fee(10);
+    input.set_sequence(22857743);
+    input.set_last_ledger_sequence(22857764);
+    input.set_account("rPa2KsEuSuZnmjosds99nhgsoiKtw85j6Z");
+    input.set_private_key(key.data(), key.size());
+
+    Proto::SigningOutput output;
+    ANY_SIGN(input, TWCoinTypeXRP);
+
+    EXPECT_EQ(hex(output.encoded()), "12001d220000000024015cc80f201b015cc824501d000b013a95f14b0044f78a264e41713c64b5f89242540ee208c3098e00000d6568400000000000000a73210331c298cb86428b9126bd4af6a952870cfe3fe5065dc093cf97f3edbb27e9dd15744630440220797922caaa593c4e91fa6b63a38c92ef9f5e2183128918dda166f4292882e137022057702b668d7463ef1d01dad5ee6633bd36f0aa358dacc90d6b68d248672a400f8114f260a758132d3ed27e52d7f55ef0481606f090d4");
+}
+
+TEST(TWAnySignerRipple, SignNfTokenCancelOffer) {
+    // https://devnet.xrpl.org/transactions/CBA148308A0D1561E5E8CDF1F2E8D5562C320C221AC4053AA5F495CEF4B5D5D4
+    auto key = parse_hex("3e50cc102d8c96abd55f047a536b6425154514ba8abdf5f09335a7c644176c5d");
+    Proto::SigningInput input;
+
+    input.mutable_op_nftoken_cancel_offer()->add_token_offers("000b013a95f14b0044f78a264e41713c64b5f89242540ee208c3098e00000d65");
+    input.set_fee(10);
+    input.set_sequence(22857838);
+    input.set_last_ledger_sequence(22857859);
+    input.set_account("rPqczdU9bzow966hQKQejsXrMJspM7G4CC");
+    input.set_private_key(key.data(), key.size());
+
+    Proto::SigningOutput output;
+    ANY_SIGN(input, TWCoinTypeXRP);
+
+    EXPECT_EQ(hex(output.encoded()), "12001c220000000024015cc86e201b015cc88368400000000000000a7321022250f103fd045edf2e552df2d20aca01a52dc6aedd522d68767f1c744fedb39d74463044022015fff495fc5d61cd71e5815e4d23845ec26f4dc94adb85207feba2c97e19856502207297ec84afc0bb74aa8a20d7254025a82d9b9f177f648845d8c72ee62884ff618114fa84c77f2a5245ef774845d40428d2a6f9603415041320000b013a95f14b0044f78a264e41713c64b5f89242540ee208c3098e00000d65");
 }
 
 } // namespace TW::Ripple::tests

--- a/tests/chains/XRP/TransactionTests.cpp
+++ b/tests/chains/XRP/TransactionTests.cpp
@@ -43,12 +43,14 @@ TEST(RippleTransaction, serialize) {
     auto account = Address("r9TeThyi5xiuUUrFjtPKZiHcDxs7K9H6Rb");
     auto destination = "r4BPgS7DHebQiU31xWELvZawwSG2fSPJ7C";
     auto tx1 = Transaction(
-       /* amount */25000000,
        /* fee */10,
        /* flags */0,
        /* sequence */2,
        /* last_ledger_sequence */0,
-       /* account */account,
+       /* account */account
+    );
+    tx1.createXrpPayment(
+       /* amount */25000000,
        /* destination */destination,
        /* destination_tag*/0
     );
@@ -56,12 +58,14 @@ TEST(RippleTransaction, serialize) {
     ASSERT_EQ(hex(serialized1), "120000220000000024000000026140000000017d784068400000000000000a81145ccb151f6e9d603f394ae778acf10d3bece874f68314e851bbbe79e328e43d68f43445368133df5fba5a");
 
     auto tx2 = Transaction(
-       /* amount */200000,
        /* fee */15,
        /* flags */0,
        /* sequence */144,
        /* last_ledger_sequence */0,
-       /* account */Address("rGWTUVmm1fB5QUjMYn8KfnyrFNgDiD9H9e"),
+       /* account */Address("rGWTUVmm1fB5QUjMYn8KfnyrFNgDiD9H9e")
+    );
+    tx2.createXrpPayment(
+       /* amount */200000,
        /* destination */"rw71Qs1UYQrSQ9hSgRohqNNQcyjCCfffkQ",
        /* destination_tag*/0
     );
@@ -69,12 +73,14 @@ TEST(RippleTransaction, serialize) {
     ASSERT_EQ(hex(serialized2), "12000022000000002400000090614000000000030d4068400000000000000f8114aa1bd19d9e87be8069fdbf6843653c43837c03c6831467fe6ec28e0464dd24fb2d62a492aac697cfad02");
 
     auto tx3 = Transaction(
-       /* amount */25000000,
        /* fee */12,
        /* flags */0,
        /* sequence */1,
        /* last_ledger_sequence */0,
-       /* account */Address("r4BPgS7DHebQiU31xWELvZawwSG2fSPJ7C"),
+       /* account */Address("r4BPgS7DHebQiU31xWELvZawwSG2fSPJ7C")
+    );
+    tx3.createXrpPayment(
+       /* amount */25000000,
        /* destination */"rBqSFEFg2B6GBMobtxnU1eLA1zbNC9NDGM",
        /* destination_tag*/4146942154
     );
@@ -82,12 +88,14 @@ TEST(RippleTransaction, serialize) {
     ASSERT_EQ(hex(serialized3), "120000220000000024000000012ef72d50ca6140000000017d784068400000000000000c8114e851bbbe79e328e43d68f43445368133df5fba5a831476dac5e814cd4aa74142c3ab45e69a900e637aa2");
 
     auto tx4 = Transaction(
-       /* amount */25000000,
        /* fee */12,
        /* flags */0,
        /* sequence */1,
        /* last_ledger_sequence */0,
-       /* account */Address("r4BPgS7DHebQiU31xWELvZawwSG2fSPJ7C"),
+       /* account */Address("r4BPgS7DHebQiU31xWELvZawwSG2fSPJ7C")
+    );
+    tx4.createXrpPayment(
+       /* amount */25000000,
        /* destination */"XVhidoXkozM5DTZFdDnJ5nYC8FPrTuJiyGh1VxSGS6RNJJ5",
        /* ignore destination_tag*/12345
     );
@@ -99,12 +107,14 @@ TEST(RippleTransaction, preImage) {
     auto account = Address("r9LqNeG6qHxjeUocjvVki2XR35weJ9mZgQ");
     auto destination = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh";
     auto tx1 = Transaction(
-        /* amount */1000,
         /* fee */10,
         /* flags */2147483648,
         /* sequence */1,
         /* last_ledger_sequence */0,
-        /* account */account,
+        /* account */account
+    );
+    tx1.createXrpPayment(
+        /* amount */1000,
         /* destination */destination,
         /* destination_tag*/0
     );


### PR DESCRIPTION
## Description

Added support for issued tokens and NFTs for the Ripple blockchain.

## How to test

Unit tests were added for the Ripple blockchain. Transactions were generated using xrpl-py and the serialized result were added as expected output in the unit tests with the same inputs. Links to the broadcasted transactions have been included in the unit tests.

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue)
fullyCanonical flag was removed as it is now deprecated and caused a mismatch with xrpl-py

* New feature (non-breaking change which adds functionality)

Payment was extended to support issued currencies. Also added factory functions for building TrustSet, NFTokenBurn, NFTokenCreateOffer, NFTokenAcceptOffer, and NFTokenCancelOffer.

## Checklist

- [x] Create pull request as draft initially, unless its complete.
- [x] Add tests to cover changes as needed.
- [x] Update documentation as needed.
- [x ] If there is a related Issue, mention it in the description.